### PR TITLE
Add more details to release commit message

### DIFF
--- a/fabdeploit/git.py
+++ b/fabdeploit/git.py
@@ -323,7 +323,13 @@ class Git(BaseCommandUtil):
 
         # create new commit
         if message is None:
-            message = datetime.datetime.now().isoformat()
+            message = (
+                "Deploying '{commit}' from branch '{release_branch}' "
+                "into '{deployment_branch}'. Date: {timestamp}".format(
+                    commit=commit,
+                    release_branch=self.release_branch,
+                    deployment_branch=release_deployment_branch,
+                    timestamp=datetime.datetime.now().isoformat()))
         if parent:
             self.release_commit = self._raw_copy_commit(commit, message=message, parents=[parent], actor=self.release_author)
         else:


### PR DESCRIPTION
Currently the release commit message only contains the timestamp. But we can integrate more information like from which branch the deployment originates to improve the traceability of the code in production.
